### PR TITLE
Support iOS and Fix React Component Warnings

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -1,53 +1,17 @@
 /**
  * Sample React Native App
  * https://github.com/facebook/react-native
- * @flow
  */
 
 import React, { Component } from 'react';
-import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
+import { AppRegistry } from 'react-native';
 
-class TicTacReact extends Component {
+import GameBoard from './scripts/GameBoard';
+
+export default class TicTacReact extends Component {
   render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          To get started, edit index.ios.js
-        </Text>
-        <Text style={styles.instructions}>
-          Press Cmd+R to reload,{'\n'}
-          Cmd+D or shake for dev menu
-        </Text>
-      </View>
-    );
+    return ( <GameBoard /> );
   }
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
-});
 
 AppRegistry.registerComponent('TicTacReact', () => TicTacReact);

--- a/scripts/GameBoard.js
+++ b/scripts/GameBoard.js
@@ -1,4 +1,5 @@
-import React, {
+import React, { Component } from 'react';
+import {
   StyleSheet,
   View,
   Text,
@@ -6,7 +7,7 @@ import React, {
 
 import Square from './Square'
 
-export default class GameBoard extends React.Component {
+export default class GameBoard extends Component {
 
   constructor(props) {
     super(props);

--- a/scripts/Square.js
+++ b/scripts/Square.js
@@ -1,10 +1,12 @@
-import React, {
+
+import React, { Component } from 'react';
+import {
   StyleSheet,
   View,
   Text,
 } from 'react-native';
 
-export default class Square extends React.Component {
+export default class Square extends Component {
 
   constructor(props) {
     super(props);


### PR DESCRIPTION
The change was quite simple i replaced the content from index.ios.js with the content of index.android.js .
Since React [0.25.1](https://github.com/facebook/react-native/releases/tag/v0.25.1) the using of the React Api from `react-native` is deprecated so instead it should required from react by it's own. In this PR i made the the fixes for components. I hope you like it :)
